### PR TITLE
feat: ✨ add Dockerfile for auth, flashcards, quiz, and client service

### DIFF
--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -7,5 +7,5 @@ RUN ./gradlew bootJar --no-daemon
 FROM eclipse-temurin:24-jre
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
-EXPOSE 8080
+EXPOSE 8083
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:24-jdk AS builder
+WORKDIR /app
+COPY . .
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:24-jre
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/auth-service/src/main/resources/application.properties
+++ b/auth-service/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=auth-service
+server.port=8083

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:19-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 3000;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/auth/ {
+        proxy_pass http://host.docker.internal:8080/api/auth/;
+    }
+
+    location /api/quiz/ {
+        proxy_pass http://host.docker.internal:8081/api/quiz/;
+    }
+
+    location /api/flashcard/ {
+        proxy_pass http://host.docker.internal:8082/api/flashcard/;
+    }
+}

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -7,15 +7,15 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    location /api/auth/ {
-        proxy_pass http://host.docker.internal:8080/api/auth/;
-    }
-
     location /api/quiz/ {
         proxy_pass http://host.docker.internal:8081/api/quiz/;
     }
 
     location /api/flashcard/ {
         proxy_pass http://host.docker.internal:8082/api/flashcard/;
+    }
+
+    location /api/auth/ {
+        proxy_pass http://host.docker.internal:8083/api/auth/;
     }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,11 +6,6 @@ function App() {
   const [flashcardMessage, setFlashcardMessage] = useState("");
 
   useEffect(() => {
-    fetch("http://localhost:8080/api/auth/test")
-      .then((res) => res.text())
-      .then(setAuthMessage)
-      .catch((err) => console.error("Error fetching from auth service:", err));
-
     fetch("http://localhost:8081/api/quiz/test")
       .then((res) => res.text())
       .then(setQuizMessage)
@@ -19,9 +14,12 @@ function App() {
     fetch("http://localhost:8082/api/flashcard/test")
       .then((res) => res.text())
       .then(setFlashcardMessage)
-      .catch((err) =>
-        console.error("Error fetching from flashcard service:", err)
-      );
+      .catch((err) => console.error("Error fetching from flashcard service:", err));
+
+    fetch("http://localhost:8083/api/auth/test")
+      .then((res) => res.text())
+      .then(setAuthMessage)
+      .catch((err) => console.error("Error fetching from auth service:", err));
   }, []);
 
   return (

--- a/flashcard-service/Dockerfile
+++ b/flashcard-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:24-jdk AS builder
+WORKDIR /app
+COPY . .
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:24-jre
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8082
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/quiz-service/Dockerfile
+++ b/quiz-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:24-jdk AS builder
+WORKDIR /app
+COPY . .
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:24-jre
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
This PR closes both #15 and #22.

- Changed the auth-service port from 8080 to 8083
- Added Dockerfile for each service

**How to test:**

1. Build and Run Each Service
```
# Auth Service
cd auth-service
docker build -t auth-service .
docker run -d -p 8083:8083 auth-service

# Quiz Service
cd ../quiz-service
docker build -t quiz-service .
docker run -d -p 8081:8081 quiz-service

# Flashcard Service
cd ../flashcard-service
docker build -t flashcard-service .
docker run -d -p 8082:8082 flashcard-service

# Client
cd ../client
docker build -t client .
docker run -d -p 3000:3000 client
```

2. Access the Application: http://localhost:3000